### PR TITLE
stream_reconnect_time should not be reset to 0

### DIFF
--- a/src/thin_connector/stream/stream_helper.rb
+++ b/src/thin_connector/stream/stream_helper.rb
@@ -10,7 +10,7 @@ module ThinConnector
       end
 
       def reset_reconnect_time
-        @stream_reconnect_time = 0
+        @stream_reconnect_time = 1
       end
 
       def max_reconnect_time


### PR DESCRIPTION
stream_reconnect_time should not be reset to 0.

The value is initialized to 1 in gnip_stream.rb.

If it is reset to 0, then any future calls to bump_reconnect_time will have no affect (because 0*2 is always 0).