### PR TITLE
Remove redundant calls to reconnect, reconnect is called in the callbacks.

### DIFF
--- a/src/thin_connector/stream/gnip_stream.rb
+++ b/src/thin_connector/stream/gnip_stream.rb
@@ -63,11 +63,9 @@ module ThinConnector
           http.stream { |chunk| process_chunk(chunk) }
           http.callback {
             handle_connection_close(http)
-            reconnect
           }
           http.errback {
             handle_error(http)
-            reconnect
           }
 
           EM.add_periodic_timer(3) do


### PR DESCRIPTION
The `handle_connection_close` and `handle_error` callbacks call the `reconnect` method, no need to call it twice.